### PR TITLE
Fix: Configure Vite Base Path for GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/portfolio/',
   plugins: [react(), tailwindcss()],
-})
+});


### PR DESCRIPTION
Resolves the "blank page" issue on the live GitHub Pages site.

This is corrected by setting the `base` option in `vite.config.js` to the repository name, which ensures all asset paths are generated correctly for the subdirectory hosting environment.